### PR TITLE
Fix scrambleNxN

### DIFF
--- a/src/scripts/scrambles.js
+++ b/src/scripts/scrambles.js
@@ -256,16 +256,12 @@ var scramble = function() {
             moves.push(i+"Dw");
         }
 
-        console.log(moves);
-
         var finalMoves = [];
         moves.forEach((element) => {
             finalMoves.push(element);
             finalMoves.push(element + "'");
             finalMoves.push(element + "2");
         });
-        
-        console.log(finalMoves);
 
         var s = "";
         for (var i = 0; i < length; i++) {

--- a/src/scripts/scrambles.js
+++ b/src/scripts/scrambles.js
@@ -238,20 +238,34 @@ var scramble = function() {
             moves.push("D");
         }
 
-        for (var i = 0; i < n / 2; i++) {
-            moves.push(i+"R");
-            moves.push(i+"L");
-            moves.push(i+"F");
-            moves.push(i+"B");
-            moves.push(i+"U");
-            moves.push(i+"D");
+        if (n > 3) {
+            moves.push("Rw");
+            moves.push("Lw");
+            moves.push("Fw");
+            moves.push("Bw");
+            moves.push("Uw");
+            moves.push("Dw");
         }
 
-        var finalMoves = moves;
-        for (var m = 0; i < moves.length; i++) {
-            finalMoves.push(moves[m] + "'");
-            finalMoves.push(moves[m] + "2");
+        for (var i = 3; i <= n / 2; i++) {
+            moves.push(i+"Rw");
+            moves.push(i+"Lw");
+            moves.push(i+"Fw");
+            moves.push(i+"Bw");
+            moves.push(i+"Uw");
+            moves.push(i+"Dw");
         }
+
+        console.log(moves);
+
+        var finalMoves = [];
+        moves.forEach((element) => {
+            finalMoves.push(element);
+            finalMoves.push(element + "'");
+            finalMoves.push(element + "2");
+        });
+        
+        console.log(finalMoves);
 
         var s = "";
         for (var i = 0; i < length; i++) {


### PR DESCRIPTION
Setting scramble to 8x8+, where scrambleNxN() was called, would result in a crash. Even after fixing the crash, the function itself didn't produce a good scramble, especially for smaller puzzles. It's still possible to get consecutive turns on the same face, such as U U', so there is work to be done, but I hope this is at least an improvement.