### PR TITLE
Fixed issue #33

### DIFF
--- a/app/scripts/tools.js
+++ b/app/scripts/tools.js
@@ -484,7 +484,7 @@ var tools = function() {
             }
             means.push(meanTimes(times));
             var ao5s = []
-            for (var x = 0;x < sessions[i].records.length - 4; x++) {    
+            for (var x = 0;x < times.length - 4; x++) {    
                 ao5s.push(averageTimes(times.slice(x,x+5)));
             }
             if (ao5s.length === 0) {


### PR DESCRIPTION
Fixed issue #33 . The loop was going through sessions[i].records.length, but this included DNF times. Fixed it by making the loop go through times.length, which had the DNF's removed. 